### PR TITLE
Add `pdm thrift` command to generate Python Thrift bindings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ style = [
     "pyright>=1.1.315",
 ]
 
+[tool.pdm.scripts]
+thrift = "thrift -r --gen py --out pymetastore static/hms.thrift"
+
 [tool.black]
 exclude = "pymetastore/hms/"
 


### PR DESCRIPTION
You'll have to have the `thrift` command installed for this to work.

On Mac, I used Brew to `brew install thrift`.