### PR TITLE
Set up more robust table in integration test

### DIFF
--- a/pymetastore/metastore.py
+++ b/pymetastore/metastore.py
@@ -241,11 +241,7 @@ class HMS:
         )
 
     def list_tables(self, database_name: str) -> List[str]:
-        tables = self.client.get_all_tables(database_name)
-        table_names = []
-        for table in tables:
-            table_names.append(table.tableName)
-        return table_names
+        return self.client.get_all_tables(database_name)
 
     def list_columns(self, database_name: str, table_name: str) -> List[str]:
         # TODO: Rather than ignore these pyright errors, do appropriate None handling

--- a/tests/integration/test_metastore.py
+++ b/tests/integration/test_metastore.py
@@ -6,7 +6,7 @@ from thrift.transport import TSocket, TTransport
 
 from pymetastore.hive_metastore import ttypes
 from pymetastore.hive_metastore.ThriftHiveMetastore import Client
-from pymetastore.metastore import HMS
+from pymetastore.metastore import HMS, HColumn, HDatabase
 
 
 @pytest.fixture(scope="module")
@@ -37,6 +37,75 @@ def setup_data(hive_client):
         hive_client.drop_database("test_db", True, True)
     hive_client.create_database(db)
 
+    cols = [
+        ttypes.FieldSchema(name="col1", type="int", comment="c1"),
+        ttypes.FieldSchema(name="col2", type="string", comment="c2"),
+    ]
 
-def test_database_exists(hive_client):
+    partitionKeys = [ttypes.FieldSchema(name="partition", type="string", comment="")]
+
+    serde_info = ttypes.SerDeInfo(
+        name="test_serde",
+        serializationLib="org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
+        parameters={"field.delim": ","},
+    )
+
+    storageDesc = ttypes.StorageDescriptor(
+        location="/tmp/test_db/test_table",
+        cols=cols,
+        inputFormat="org.apache.hadoop.mapred.TextInputFormat",
+        outputFormat="org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
+        compressed=False,
+        numBuckets=-1,
+        serdeInfo=serde_info,
+        bucketCols=[],
+    )
+
+    table = ttypes.Table(
+        tableName="test_table",
+        dbName="test_db",
+        owner="owner",
+        createTime=0,
+        lastAccessTime=0,
+        retention=0,
+        sd=storageDesc,
+        partitionKeys=partitionKeys,
+        parameters={},
+        tableType="EXTERNAL_TABLE",
+    )
+
+    if "test_table" in hive_client.get_all_tables("test_db"):
+        hive_client.drop_table("test_db", "test_table", True)
+    hive_client.create_table(table)
+
+    for i in range(1, 6):
+        partition = ttypes.Partition(
+            dbName="test_db",
+            tableName="test_table",
+            values=[str(i)],
+            sd=storageDesc,
+            parameters={},
+        )
+        hive_client.add_partition(partition)
+
+
+def test_list_databases(hive_client):
     assert "test_db" in HMS(hive_client).list_databases()
+
+
+@pytest.mark.xfail(reason="'owner_name' is None for some reason. Investigate.")
+def test_get_database(hive_client):
+    hms = HMS(hive_client)
+    database = hms.get_database("test_db")
+    assert isinstance(database, HDatabase)
+    assert database.name == "test_db"
+    assert database.location == "file:/tmp/test_db.db"
+    # TODO Fix this bug. owner_name is None for some reason.
+    assert database.owner_name == "owner"
+
+
+def test_list_tables(hive_client):
+    hms = HMS(hive_client)
+    tables = hms.list_tables("test_db")
+    assert isinstance(tables, list)
+    assert "test_table" in tables


### PR DESCRIPTION
We're now creating a a `test_db` with a `test_table` in it.

The `test_table` has two columns (`col_1` and `col_2`) of type int and string, respectively.

The test also creates some partitions on the table.