### PR TITLE
Integration tests

### DIFF
--- a/tests/integration/test_metastore.py
+++ b/tests/integration/test_metastore.py
@@ -6,7 +6,8 @@ from thrift.transport import TSocket, TTransport
 
 from pymetastore.hive_metastore import ttypes
 from pymetastore.hive_metastore.ThriftHiveMetastore import Client
-from pymetastore.metastore import HMS, HColumn, HDatabase
+from pymetastore.htypes import HPrimitiveType, HType, HTypeCategory
+from pymetastore.metastore import HMS, HColumn, HDatabase, HTable
 
 
 @pytest.fixture(scope="module")
@@ -108,3 +109,55 @@ def test_list_tables(hive_client):
     tables = hms.list_tables("test_db")
     assert isinstance(tables, list)
     assert "test_table" in tables
+
+
+def test_get_table(hive_client):
+    hms = HMS(hive_client)
+    table = hms.get_table("test_db", "test_table")
+    assert isinstance(table, HTable)
+    assert table.database_name == "test_db"
+    assert table.name == "test_table"
+    assert table.owner == "owner"
+    assert table.storage.location == "file:/tmp/test_db/test_table"
+    assert len(table.columns) == 2
+    assert isinstance(table.columns[0], HColumn)
+    assert isinstance(table.columns[1], HColumn)
+    assert len(table.partition_columns) == 1
+    assert isinstance(table.partition_columns[0], HColumn)
+    assert isinstance(table.parameters, dict)
+    assert len(table.parameters) == 1
+    assert (
+        table.parameters.get("transient_lastDdlTime") is not None
+    )  # this is not a parameter of the table we created, but the metastore adds it
+    # This assertion fails, I leave it here on purpose. My current assumption is that the metastore overrides some of the passed options with defaults. "MANAGEd_TABLE" is the default value for tableType
+    # See here for the defaults: https://github.com/apache/hive/blob/14a1f70607db5ae6cf71b6d4343f308a5167581c/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/client/builder/TableBuilder.java#L69C43-L69C43
+    # Something similar happens also when you choose a "VIRTUAL_VIEW" table type, where the metastore overrides the storage descriptor removing in the location the file:: prefix.
+    assert table.table_type == "EXTERNAL_TABLE"
+
+
+def test_get_table_columns(hive_client):
+    hms = HMS(hive_client)
+    table = hms.get_table("test_db", "test_table")
+    columns = table.columns
+    partition_columns = table.partition_columns
+
+    assert columns[0].name == "col1"
+    assert isinstance(columns[0].type, HType)
+    assert isinstance(columns[0].type, HPrimitiveType)
+    assert columns[0].type.name == "INT"
+    assert columns[0].type.category == HTypeCategory.PRIMITIVE
+    assert columns[0].comment == "c1"
+
+    assert columns[1].name == "col2"
+    assert isinstance(columns[1].type, HType)
+    assert isinstance(columns[1].type, HPrimitiveType)
+    assert columns[1].type.name == "STRING"
+    assert columns[1].type.category == HTypeCategory.PRIMITIVE
+    assert columns[1].comment == "c2"
+
+    assert partition_columns[0].name == "partition"
+    assert isinstance(partition_columns[0].type, HType)
+    assert isinstance(partition_columns[0].type, HPrimitiveType)
+    assert partition_columns[0].type.name == "STRING"
+    assert partition_columns[0].type.category == HTypeCategory.PRIMITIVE
+    assert partition_columns[0].comment == ""

--- a/tests/integration/test_metastore.py
+++ b/tests/integration/test_metastore.py
@@ -31,6 +31,7 @@ def setup_data(hive_client):
         description="This is a test database",
         locationUri="/tmp/test_db.db",
         parameters={},
+        ownerName="owner",
     )
 
     if "test_db" in hive_client.get_all_databases():
@@ -93,14 +94,12 @@ def test_list_databases(hive_client):
     assert "test_db" in HMS(hive_client).list_databases()
 
 
-@pytest.mark.xfail(reason="'owner_name' is None for some reason. Investigate.")
 def test_get_database(hive_client):
     hms = HMS(hive_client)
     database = hms.get_database("test_db")
     assert isinstance(database, HDatabase)
     assert database.name == "test_db"
     assert database.location == "file:/tmp/test_db.db"
-    # TODO Fix this bug. owner_name is None for some reason.
     assert database.owner_name == "owner"
 
 


### PR DESCRIPTION
Basic tests for fetching tables and columns. At least for the basic types it seems to work fine. I'll be adding more tests to cover all the different types but it should be ok to start playing around with converting the types into Recap. Btw, there's a failing assertion in the tests right now but check my commit comments and the source code for that. 