### PR TITLE
Adding a more complete README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ pip install pymetastore
 
 ## Quick Start
 
-Here's a taste of using `pymetastore` to connect to Hive Metastore and list all databases:
+Here's a taste of using `pymetastore` to connect to Hive Metastore and interact with metadata:
 
 ```python
 from pymetastore.metastore import HMS
@@ -25,6 +25,30 @@ from pymetastore.metastore import HMS
 # create a connection to Hive Metastore
 with HMS.create(host="localhost", port=9083) as hms:
     # list all databases
-    databases = hms.client.get_all_databases()
-    print(databases)
+    databases = hms.list_databases()
+
+    # get a database
+    database = hms.get_database(name="test_db")
+
+    # list all tables in a database
+    tables = hms.list_tables(database_name=database.name)
+
+    # get a table
+    table = hms.get_table(
+        database_name=database.name,
+        table_name=tables[0],
+    )
+
+    # list all partitions of a table
+    partitions = hms.list_partitions(
+        database_name=database.name,
+        table_name=table.name,
+    )
+
+    # get a partition
+    partition = hms.get_partition(
+        database_name=database.name,
+        table_name=table.name,
+        partition_name="partition=1",
+    )
 ```


### PR DESCRIPTION
The README now shows how to get more metadata from the client (not just list databases).

I also discovered two bugs, which I fixed.

1. _HMSConnection was returning a hms.Client not a HMS.
2. Partitions had and `is None` instead of `is not None`