### PR TITLE
repr(), str() and eq() for Hive Types

### DIFF
--- a/pymetastore/htypes.py
+++ b/pymetastore/htypes.py
@@ -38,11 +38,29 @@ class HType:
         self.name = name
         self.category = category
 
+    def __str__(self):
+        return f"{self.__class__.__name__}(name={self.name}, category={self.category})"
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}('{self.name}', {self.category})"
+
+    def __eq__(self, other):
+        if isinstance(other, HType):
+            return (self.name == other.name) and (self.category == other.category)
+        else:
+            return False
+
 
 class HPrimitiveType(HType):
     def __init__(self, primitive_type: PrimitiveCategory):
         super().__init__(primitive_type.value, HTypeCategory.PRIMITIVE)
         self.primitive_type = primitive_type
+
+    def __str__(self):
+        return f"{self.__class__.__name__}(name={self.name}, category={self.category})"
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self.primitive_type})"
 
 
 class HMapType(HType):
@@ -51,17 +69,57 @@ class HMapType(HType):
         self.key_type = key_type
         self.value_type = value_type
 
+    def __str__(self):
+        return f"{super().__str__()}, key_type={str(self.key_type)}, value_type={str(self.value_type)})"
+
+    def __repr__(self):
+        return f"HMapType({repr(self.key_type)}, {repr(self.value_type)})"
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return (
+                super().__eq__(other)
+                and (self.key_type == other.key_type)
+                and (self.value_type == other.value_type)
+            )
+        else:
+            return False
+
 
 class HListType(HType):
     def __init__(self, element_type: HType):
         super().__init__("LIST", HTypeCategory.LIST)
         self.element_type = element_type
 
+    def __str__(self):
+        return f"{super().__str__()}, element_type={str(self.element_type)})"
+
+    def __repr__(self):
+        return f"HListType({repr(self.element_type)})"
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return super().__eq__(other) and (self.element_type == other.element_type)
+        else:
+            return False
+
 
 class HUnionType(HType):
     def __init__(self, types: List[HType]):
         super().__init__("UNION", HTypeCategory.UNION)
         self.types = types
+
+    def __str__(self):
+        return f"{super().__str__()}, types={str(self.types)})"
+
+    def __repr__(self):
+        return f"HUnionType({repr(self.types)})"
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return super().__eq__(other) and (self.types == other.types)
+        else:
+            return False
 
 
 class HVarcharType(HType):
@@ -72,6 +130,18 @@ class HVarcharType(HType):
         super().__init__("VARCHAR", HTypeCategory.PRIMITIVE)
         self.length = length
 
+    def __str__(self):
+        return f"HVarcharType(length={self.length})"
+
+    def __repr__(self):
+        return f"HVarcharType({self.length})"
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return super().__eq__(other) and (self.length == other.length)
+        else:
+            return False
+
 
 class HCharType(HType):
     def __init__(self, length: int):
@@ -80,6 +150,18 @@ class HCharType(HType):
             raise ValueError("Char length cannot exceed 255")
         super().__init__("CHAR", HTypeCategory.PRIMITIVE)
         self.length = length
+
+    def __str__(self):
+        return f"HCharType(length={self.length})"
+
+    def __repr__(self):
+        return f"HCharType({self.length})"
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return super().__eq__(other) and (self.length == other.length)
+        else:
+            return False
 
 
 class HDecimalType(HType):
@@ -94,6 +176,22 @@ class HDecimalType(HType):
         self.precision = precision
         self.scale = scale
 
+    def __str__(self):
+        return f"HDecimalType(precision={self.precision}, scale={self.scale})"
+
+    def __repr__(self):
+        return f"HDecimalType({self.precision}, {self.scale})"
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return (
+                super().__eq__(other)
+                and (self.precision == other.precision)
+                and (self.scale == other.scale)
+            )
+        else:
+            return False
+
 
 class HStructType(HType):
     def __init__(self, names: List[str], types: List[HType]):
@@ -107,6 +205,22 @@ class HStructType(HType):
         super().__init__("STRUCT", HTypeCategory.STRUCT)
         self.names = names
         self.types = types
+
+    def __str__(self):
+        return f"{super().__str__()}, names={self.names}, types={self.types})"
+
+    def __repr__(self):
+        return f"HStructType({self.names}, {self.types})"
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return (
+                super().__eq__(other)
+                and (self.names == other.names)
+                and (self.types == other.types)
+            )
+        else:
+            return False
 
 
 # We need to maintain a list of the expected serialized type names.

--- a/tests/unit/test_htypes.py
+++ b/tests/unit/test_htypes.py
@@ -7,6 +7,7 @@ from pymetastore.htypes import (
     HMapType,
     HPrimitiveType,
     HStructType,
+    HType,
     HTypeCategory,
     HUnionType,
     HVarcharType,
@@ -484,3 +485,116 @@ def test_union_type_parser():
     assert ptype.types[0].category == HPrimitiveType(PrimitiveCategory.INT).category
     assert ptype.types[1].name == "STRING"
     assert ptype.types[1].category == HPrimitiveType(PrimitiveCategory.STRING).category
+
+
+def test_htype_str_repr():
+    ex = HType("int", PrimitiveCategory.INT)
+    assert str(ex) == "HType(name=int, category=PrimitiveCategory.INT)"
+    assert repr(ex) == "HType('int', PrimitiveCategory.INT)"
+    clone = eval(repr(ex))
+    assert clone == ex
+
+
+def test_hmap_type_str_repr_and_eq():
+    typ = HMapType(
+        HPrimitiveType(PrimitiveCategory.STRING), HPrimitiveType(PrimitiveCategory.INT)
+    )
+    assert isinstance(typ, HMapType)
+    assert (
+        str(typ)
+        == "HMapType(name=MAP, category=HTypeCategory.MAP), key_type=HPrimitiveType(name=STRING, category=HTypeCategory.PRIMITIVE), value_type=HPrimitiveType(name=INT, category=HTypeCategory.PRIMITIVE))"
+    )
+    assert (
+        repr(typ)
+        == "HMapType(HPrimitiveType(PrimitiveCategory.STRING), HPrimitiveType(PrimitiveCategory.INT))"
+    )
+
+    clone = eval(repr(typ))
+    assert clone == typ
+
+
+def test_hlist_type_str_repr_and_eq():
+    _type = HListType(HPrimitiveType(PrimitiveCategory.INT))
+    assert isinstance(_type, HListType)
+    assert (
+        str(_type)
+        == "HListType(name=LIST, category=HTypeCategory.LIST), element_type=HPrimitiveType(name=INT, category=HTypeCategory.PRIMITIVE))"
+    )
+    assert repr(_type) == "HListType(HPrimitiveType(PrimitiveCategory.INT))"
+
+    clone = eval(repr(_type))
+    assert clone == _type
+
+
+def test_hunion_type_str_repr_and_eq():
+    _type = HUnionType(
+        [
+            HPrimitiveType(PrimitiveCategory.INT),
+            HPrimitiveType(PrimitiveCategory.STRING),
+        ]
+    )
+    assert isinstance(_type, HUnionType)
+    assert (
+        str(_type)
+        == "HUnionType(name=UNION, category=HTypeCategory.UNION), types=[HPrimitiveType(PrimitiveCategory.INT), HPrimitiveType(PrimitiveCategory.STRING)])"
+    )
+    assert (
+        repr(_type)
+        == "HUnionType([HPrimitiveType(PrimitiveCategory.INT), HPrimitiveType(PrimitiveCategory.STRING)])"
+    )
+
+    clone = eval(repr(_type))
+    assert clone == _type
+
+
+def test_hvarchar_type_str_repr_and_eq():
+    _type = HVarcharType(10)
+    assert isinstance(_type, HVarcharType)
+    assert str(_type) == "HVarcharType(length=10)"
+    assert repr(_type) == "HVarcharType(10)"
+
+    clone = eval(repr(_type))
+    assert clone == _type
+
+
+def test_hchar_type_str_repr_and_eq():
+    _type = HCharType(10)
+    assert isinstance(_type, HCharType)
+    assert str(_type) == "HCharType(length=10)"
+    assert repr(_type) == "HCharType(10)"
+
+    clone = eval(repr(_type))
+    assert clone == _type
+
+
+def test_hdecimal_type_str_repr_and_eq():
+    _type = HDecimalType(10, 2)
+    assert isinstance(_type, HDecimalType)
+    assert str(_type) == "HDecimalType(precision=10, scale=2)"
+    assert repr(_type) == "HDecimalType(10, 2)"
+
+    clone = eval(repr(_type))
+    assert clone == _type
+
+
+def test_hstruct_type_str_repr_and_eq():
+    _type = HStructType(
+        ["name", "age"],
+        [
+            HPrimitiveType(PrimitiveCategory.STRING),
+            HPrimitiveType(PrimitiveCategory.INT),
+        ],
+    )
+    assert isinstance(_type, HStructType)
+
+    assert (
+        str(_type)
+        == "HStructType(name=STRUCT, category=HTypeCategory.STRUCT), names=['name', 'age'], types=[HPrimitiveType(PrimitiveCategory.STRING), HPrimitiveType(PrimitiveCategory.INT)])"
+    )
+    assert (
+        repr(_type)
+        == "HStructType(['name', 'age'], [HPrimitiveType(PrimitiveCategory.STRING), HPrimitiveType(PrimitiveCategory.INT)])"
+    )
+
+    clone = eval(repr(_type))
+    assert clone == _type


### PR DESCRIPTION
added repr(), str() and eq() implementations for all the Hive types plus tests to ensure the format and that eval can recreate the objects from the repr() result