### PR TITLE
Make `get_table_stats` return all columns by default

### DIFF
--- a/pymetastore/metastore.py
+++ b/pymetastore/metastore.py
@@ -633,14 +633,14 @@ class HMS:
     def get_table_stats(
         self,
         table: HTable,
-        columns: List[HColumn],
+        columns: List[HColumn] | None = None,
     ) -> List[ColumnStats]:
-        assert isinstance(table, HTable)
-        assert isinstance(columns, list)
+        columns = columns or []
 
         if len(columns) > 0:
             assert all(isinstance(column, HColumn) for column in columns)
 
+        assert isinstance(table, HTable)
         assert table.name is not None
         assert table.database_name is not None
         assert table.columns is not None


### PR DESCRIPTION
I was getting annoyed setting `[]` for columns, so I made it default to the full column list.