### PR TITLE
Make `test_get_table` work with `EXTERNAL_TABLE`s

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
 
     services:
       hive-metastore:
-        image: ghcr.io/criccomini/hive-metastore-standalone:latest
+        image: ghcr.io/recap-build/hive-metastore-standalone:latest
         ports:
           - 9083:9083
 

--- a/tests/integration/test_metastore.py
+++ b/tests/integration/test_metastore.py
@@ -135,7 +135,9 @@ def setup_data(hive_client):
         retention=0,
         sd=storage_desc,
         partitionKeys=partition_keys,
-        parameters={},
+        # We have to manually set the EXTERNAL parameter to TRUE, otherwise the
+        # metastore returns tableType=None. See https://github.com/recap-build/pymetastore/issues/37.
+        parameters={"EXTERNAL": "TRUE"},
         tableType="EXTERNAL_TABLE",
     )
 
@@ -192,7 +194,9 @@ def setup_data(hive_client):
         retention=0,
         sd=storage_desc,
         partitionKeys=partition_keys,
-        parameters={},
+        # We have to manually set the EXTERNAL parameter to TRUE, otherwise the
+        # metastore returns tableType=None. See https://github.com/recap-build/pymetastore/issues/37.
+        parameters={"EXTERNAL": "TRUE"},
         tableType="EXTERNAL_TABLE",
     )
 
@@ -231,7 +235,9 @@ def setup_data(hive_client):
         retention=0,
         sd=storage_desc,
         partitionKeys=partition_keys,
-        parameters={},
+        # We have to manually set the EXTERNAL parameter to TRUE, otherwise the
+        # metastore returns tableType=None. See https://github.com/recap-build/pymetastore/issues/37.
+        parameters={"EXTERNAL": "TRUE"},
         tableType="EXTERNAL_TABLE",
     )
 
@@ -269,7 +275,9 @@ def setup_data(hive_client):
         retention=0,
         sd=storage_desc,
         partitionKeys=partition_keys,
-        parameters={},
+        # We have to manually set the EXTERNAL parameter to TRUE, otherwise the
+        # metastore returns tableType=None. See https://github.com/recap-build/pymetastore/issues/37.
+        parameters={"EXTERNAL": "TRUE"},
         tableType="EXTERNAL_TABLE",
     )
 
@@ -394,7 +402,6 @@ def test_list_tables(hive_client):
     assert "test_table" in tables
 
 
-@pytest.mark.xfail(reason="'table_type' is coming back MANAGED_TABLE.")
 # pylint: disable=redefined-outer-name
 def test_get_table(hive_client):
     """
@@ -423,16 +430,10 @@ def test_get_table(hive_client):
     assert len(table.partition_columns) == 1
     assert isinstance(table.partition_columns[0], HColumn)
     assert isinstance(table.parameters, dict)
-    assert len(table.parameters) == 1
+    assert len(table.parameters) == 2
+    assert table.parameters.get("EXTERNAL") == "TRUE"
     # this is not a parameter of the table we created, but the metastore adds it
     assert table.parameters.get("transient_lastDdlTime") is not None
-    # This assertion fails, I leave it here on purpose. My current assumption is that
-    # the metastore overrides some of the passed options with defaults. "MANAGEd_TABLE"
-    # is the default value for tableType. See here for the defaults:
-    # https://github.com/apache/hive/blob/14a1f70607db5ae6cf71b6d4343f308a5167581c/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/client/builder/TableBuilder.java#L69C43-L69C43
-    # Something similar happens also when you choose a "VIRTUAL_VIEW" table type, where
-    # the metastore overrides the storage descriptor removing in the location the file::
-    # prefix.
     assert table.table_type == "EXTERNAL_TABLE"
 
 


### PR DESCRIPTION
A user reported a bug with `EXTERNAL_TABLE`s. HMS was responding with
`tableType = 'MANAGED_TABLE'`. It turns out, we already had a test for this,
which we'd marked as `xfail` for this very reason.

This PR does a number of things:

* Updates hive metastore standalone to use Hive 3.1.3
* Update tests to set `parameters={"EXTERNAL": "TRUE"}`

I did the HMS upgrade because I wanted to verify that the HMS bug hadn't been
fixed later. The tests still failed, so I moved forward with the test fixes.
Users will need to know to set `parameters={"EXTERNAL": "TRUE"}` when creating
external tables. They can see this by looking at the tests.

I suspect the issue is really with a gap in the Thrift protocol. I suspect Hive
Metastore expects `parameters` to have the `EXTERNAL` field set for external
tables. The Python client is, however, just code gen'd from the .thrift files,
which doesn't automatically set `EXTERNAL` when the `tableType` is set. I don't
want to modify the code gen'd code; this is a big no-no. As a result, I'm
leaving it as-is. Users will just have a rouge edge to deal with.

Closes https://github.com/recap-build/pymetastore/issues/37